### PR TITLE
feat: Add URL dumping support via Exa API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a CLI tool called `dump` that recursively walks through directories and outputs text files in a structured format (XML or Markdown) for easy consumption by LLMs. The tool respects `.gitignore` files and provides flexible filtering options.
+This is a CLI tool called `dump` that recursively walks through directories and outputs text files in a structured format (XML or Markdown) for easy consumption by LLMs. The tool respects `.gitignore` files, provides flexible filtering options, and can also fetch content from URLs via the Exa API.
 
 ## Build and Development Commands
 
@@ -46,8 +46,10 @@ make run
 The codebase is a single-file Go application (`main.go`) with comprehensive test coverage (`main_test.go`). Key architectural components:
 
 ### Core Data Structures
-- `arrayFlags`: Custom flag type for handling repeated CLI arguments (e.g., multiple `-i` patterns)
-- `fileOutput`: Represents a file with its path and content for output formatting
+- `arrayFlags`: Custom flag type for handling repeated CLI arguments (e.g., multiple `-i` patterns, `-u` URLs)
+- `fileOutput`: Represents a file or URL with its path/URL and content for output formatting
+- `ExaRequest`: Structure for Exa API requests with URLs, text extraction settings, and livecrawl options
+- `ExaResponse`: Structure for parsing Exa API responses with results and context field
 
 ### Key Functions
 - `isTextFile()`: Determines if a file is text-based by checking UTF-8 validity and absence of null bytes
@@ -55,13 +57,14 @@ The codebase is a single-file Go application (`main.go`) with comprehensive test
 - `compilePatterns()`: Compiles glob patterns for file matching
 - `processDirectory()`: Concurrent directory walker that respects ignore patterns
 - `dumpFile()`: Reads file content and applies line-level filtering via regex
-- `formatOutput()`: Formats file content as XML or Markdown
+- `fetchURLContent()`: Fetches web content from URLs using Exa API with proper error handling
+- `formatOutput()`: Formats file or URL content as XML or Markdown with appropriate attributes
 
 ### Concurrency Model
-The tool uses goroutines with `sync.WaitGroup` for concurrent directory processing. Each directory is processed in its own goroutine with mutex-protected shared state for collecting results.
+The tool uses goroutines with `sync.WaitGroup` for concurrent directory processing. Each directory is processed in its own goroutine with mutex-protected shared state for collecting results. URL fetching is done sequentially after local file processing to respect API rate limits.
 
 ### CLI Interface
-Uses Go's `flag` package with custom `arrayFlags` type to support repeated arguments. Supports both short (`-i`) and long (`--ignore`) flag formats.
+Uses Go's `flag` package with custom `arrayFlags` type to support repeated arguments. Supports both short (`-i`, `-u`) and long (`--ignore`, `--url`) flag formats. URL functionality requires the `EXA_API_KEY` environment variable.
 
 ## Dependencies
 
@@ -77,3 +80,39 @@ The test suite (`main_test.go`) provides comprehensive coverage including:
 - Edge case handling (empty files, binary files, non-existent files)
 
 All tests use temporary directories and files to avoid affecting the repository state.
+
+## URL Dumping Feature
+
+The tool supports fetching content from URLs via the Exa API in addition to processing local files.
+
+### Usage
+```bash
+# Fetch content from URLs alongside local files
+dump -d src/ -u https://docs.example.com/api -u https://github.com/user/repo
+
+# URL-only dumping
+dump -u https://example.com/documentation
+
+# Mix with other options
+dump -g "*.go" -u https://golang.org/doc/ -o md
+```
+
+### Requirements
+- `EXA_API_KEY` environment variable must be set
+- URLs are processed after all local file processing completes
+- API calls have a 30-second timeout
+
+### Output Format
+- **XML**: `<file url='https://example.com'>content</file>`
+- **Markdown**: ````https://example.com\ncontent\n````
+
+### Error Handling
+- Missing API key: Error logged to stderr, local files still processed
+- Individual URL failures: Error logged to stderr, other URLs still processed
+- Network issues: Graceful handling with descriptive error messages
+
+### API Integration
+Uses Exa's `/contents` endpoint with:
+- `text: true` for text extraction
+- `livecrawl: "always"` for fresh content
+- Returns the `context` field containing combined text content

--- a/main.go
+++ b/main.go
@@ -306,6 +306,8 @@ func init() {
   respecting .gitignore and custom ignore rules.
   can also fetch content from URLs via Exa API.
 
+  if no content sources are specified (directories or URLs), defaults to current directory.
+
 options:
   -d|--dir <value>       directory to scan (can be repeated)
   -g|--glob <value>      glob pattern to match (can be repeated)
@@ -323,6 +325,11 @@ options:
 
 environment variables:
   EXA_API_KEY            required for URL fetching via Exa API
+
+examples:
+  dump                   dumps current directory (default behavior)
+  dump -u https://...    dumps only specified URL
+  dump -d src -u https://...  dumps src directory and URL
 `)
 	}
 }
@@ -355,7 +362,7 @@ func main() {
 	allDirs := append([]string{}, dirs...)
 	allDirs = append(allDirs, flag.Args()...)
 
-	if len(allDirs) == 0 {
+	if len(allDirs) == 0 && len(urls) == 0 {
 		allDirs = []string{"."}
 	}
 

--- a/main.go
+++ b/main.go
@@ -274,8 +274,12 @@ func fetchURLsConcurrently(urls []string, apiKey string, liveCrawl bool, timeout
 }
 
 func fetchURLContent(targetURL string, apiKey string, liveCrawl bool, timeoutSec int) (*Dumped, error) {
-	if _, err := url.ParseRequestURI(targetURL); err != nil {
+	u, err := url.ParseRequestURI(targetURL)
+	if err != nil {
 		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("URL must use HTTP or HTTPS scheme")
 	}
 
 	reqBody := ExaRequest{

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -273,6 +274,10 @@ func fetchURLsConcurrently(urls []string, apiKey string, liveCrawl bool, timeout
 }
 
 func fetchURLContent(targetURL string, apiKey string, liveCrawl bool, timeoutSec int) (*Dumped, error) {
+	if _, err := url.ParseRequestURI(targetURL); err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
 	reqBody := ExaRequest{
 		URLs:      []string{targetURL},
 		Text:      true,

--- a/main_test.go
+++ b/main_test.go
@@ -87,28 +87,28 @@ func TestIsTextFile(t *testing.T) {
 func TestFormatOutput(t *testing.T) {
 	testCases := []struct {
 		name   string
-		output fileOutput
+		output Dumped
 		format string
 		tag    string
 		expected string
 	}{
 		{
 			name: "XML format",
-			output: fileOutput{path: "src/main.go", content: "package main\nfunc main() {}\n"},
+			output: Dumped{path: "src/main.go", content: "package main\nfunc main() {}\n"},
 			format: "xml",
 			tag:    "file",
 			expected: "<file path='src/main.go'>\npackage main\nfunc main() {}\n</file>\n",
 		},
 		{
 			name: "Markdown format",
-			output: fileOutput{path: "src/main.go", content: "package main\nfunc main() {}\n"},
+			output: Dumped{path: "src/main.go", content: "package main\nfunc main() {}\n"},
 			format: "md",
 			tag:    "file", // Tag is ignored for md format
 			expected: "```src/main.go\npackage main\nfunc main() {}\n```\n",
 		},
 		{
 			name: "XML with custom tag",
-			output: fileOutput{path: "test.txt", content: "hello world\n"},
+			output: Dumped{path: "test.txt", content: "hello world\n"},
 			format: "xml",
 			tag:    "source",
 			expected: "<source path='test.txt'>\nhello world\n</source>\n",

--- a/main_test.go
+++ b/main_test.go
@@ -2,13 +2,13 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
 	"testing"
-	"bytes"
 
 	"github.com/gobwas/glob"
 	ignore "github.com/sabhiram/go-gitignore"
@@ -86,32 +86,46 @@ func TestIsTextFile(t *testing.T) {
 
 func TestFormatOutput(t *testing.T) {
 	testCases := []struct {
-		name   string
-		output Dumped
-		format string
-		tag    string
+		name     string
+		output   Dumped
+		format   string
+		tag      string
 		expected string
 	}{
 		{
-			name: "XML format",
-			output: Dumped{path: "src/main.go", content: "package main\nfunc main() {}\n"},
-			format: "xml",
-			tag:    "file",
+			name:     "XML format",
+			output:   Dumped{path: "src/main.go", content: "package main\nfunc main() {}\n"},
+			format:   "xml",
+			tag:      "file",
 			expected: "<file path='src/main.go'>\npackage main\nfunc main() {}\n</file>\n",
 		},
 		{
-			name: "Markdown format",
-			output: Dumped{path: "src/main.go", content: "package main\nfunc main() {}\n"},
-			format: "md",
-			tag:    "file", // Tag is ignored for md format
+			name:     "Markdown format",
+			output:   Dumped{path: "src/main.go", content: "package main\nfunc main() {}\n"},
+			format:   "md",
+			tag:      "file", // Tag is ignored for md format
 			expected: "```src/main.go\npackage main\nfunc main() {}\n```\n",
 		},
 		{
-			name: "XML with custom tag",
-			output: Dumped{path: "test.txt", content: "hello world\n"},
-			format: "xml",
-			tag:    "source",
+			name:     "XML with custom tag",
+			output:   Dumped{path: "test.txt", content: "hello world\n"},
+			format:   "xml",
+			tag:      "source",
 			expected: "<source path='test.txt'>\nhello world\n</source>\n",
+		},
+		{
+			name:     "URL with XML format",
+			output:   Dumped{path: "https://example.com", content: "web content\n"},
+			format:   "xml",
+			tag:      "file",
+			expected: "<web url='https://example.com'>\nweb content\n</web>\n",
+		},
+		{
+			name:     "URL with Markdown format",
+			output:   Dumped{path: "https://example.com", content: "web content\n"},
+			format:   "md",
+			tag:      "file",
+			expected: "```https://example.com\nweb content\n```\n",
 		},
 	}
 
@@ -554,22 +568,22 @@ func TestArrayFlags(t *testing.T) {
 
 	t.Run("Set method", func(t *testing.T) {
 		af := arrayFlags{}
-		
+
 		err := af.Set("*.go")
 		if err != nil {
 			t.Errorf("Set() returned unexpected error: %v", err)
 		}
-		
+
 		err = af.Set("*.js")
 		if err != nil {
 			t.Errorf("Set() returned unexpected error: %v", err)
 		}
-		
+
 		expected := arrayFlags{"*.go", "*.js"}
 		if len(af) != len(expected) {
 			t.Errorf("Set() length = %d, expected %d", len(af), len(expected))
 		}
-		
+
 		for i, v := range expected {
 			if af[i] != v {
 				t.Errorf("Set() af[%d] = %q, expected %q", i, af[i], v)
@@ -577,4 +591,3 @@ func TestArrayFlags(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION
## Summary
- Add support for fetching web content from URLs using the Exa API
- Implement `-u < /dev/null | --url` flags that accept multiple URLs using arrayFlags pattern
- Add proper error handling and authentication via `EXA_API_KEY` environment variable

## Key Features
- **Multiple URL support**: Use `-u` or `--url` flags repeatedly for multiple URLs
- **Exa API integration**: Fetches content using POST `/contents` endpoint with proper authentication
- **Error handling**: Graceful handling of missing API keys, network issues, and individual URL failures
- **Output formatting**: Support for both XML (`<file url='...'>`) and Markdown formats
- **Processing order**: URLs processed after local files as specified
- **30-second timeout**: Prevents hanging on slow API requests

## Usage Examples
```bash
# Basic URL fetching
EXA_API_KEY=your-key dump -u https://example.com

# Combined with local files
EXA_API_KEY=your-key dump -d ./src -u https://docs.example.com

# Multiple URLs with Markdown output
EXA_API_KEY=your-key dump -u https://site1.com -u https://site2.com -o md
```

## Changes Made
- Added URL flag support using existing arrayFlags pattern
- Implemented Exa API client with proper authentication
- Added URL-specific output formatting for both XML and Markdown
- Updated help text to include new functionality
- Enhanced CLAUDE.md documentation with usage examples
- All existing functionality preserved (tests passing)

## Test plan
- [x] Verify build succeeds
- [x] Test help output includes new flags
- [x] Test error handling without API key
- [x] Verify existing tests still pass
- [x] Test mixed local files and URL usage
- [ ] Test with valid Exa API key (requires manual testing)
- [ ] Verify XML and Markdown output formats for URLs
- [ ] Test error handling for invalid URLs

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for fetching and processing content from URLs via the Exa API in addition to local files.
  * Introduced new command-line options (`-u`, `--url`, `--live`, `--timeout`) to specify URLs, live crawl behavior, and request timeouts.
  * Output now includes content fetched from URLs, with appropriate formatting for both XML and Markdown.
  * Added requirement for the `EXA_API_KEY` environment variable to enable URL fetching.
  * URL fetching occurs sequentially after local file processing with concurrency and rate limiting to respect API constraints.
  * Enhanced error handling logs issues during URL fetching without interrupting overall processing.

* **Documentation**
  * Updated documentation to detail the new URL dumping feature, usage examples, API requirements, output formats, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->